### PR TITLE
WIP: Syntax updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,82 @@ class Point3 {
 
 ### Syntax ###
 
-TODO
+  [12.2.5 Object Initializer](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initializer)
+  
+  ```
+  PropertyDefinition[Yield] :
+    IdentifierReference[?Yield]
+    CoverInitializedName[?Yield]
+    PropertyName[?Yield] TypeHint  : AssignmentExpression[In, ?Yield]
+    MethodDefinition[?Yield]
+    
+  CoverInitializedName[Yield] :
+    IdentifierReference[?Yield] TypeHint Initializer[In, ?Yield]
+  
+  
+  ```
+  [12.14.5 Destructuring Assignment](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment)
+  ```
+  AssignmentProperty[Yield] :
+    IdentifierReference[?Yield] TypeHint Initializer[In,?Yield]opt
+    PropertyName TypeHint : AssignmentElement[?Yield]
+  ```
+  
+  [13.2.1 Let and Const Declarations](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations)
+  ```
+  LexicalBinding[In, Yield] :
+    BindingIdentifier[?Yield] TypeHint Initializer[?In, ?Yield]opt
+    BindingPattern[?Yield] Initializer[?In, ?Yield]
+  ```
+  
+  [13.2.2 Variable Statement](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-variable-statement)
+  ```
+  VariableDeclaration[In, Yield] :
+    BindingIdentifier[?Yield] TypeHint Initializer[?In, ?Yield]opt
+    BindingPattern[?Yield] Initializer[?In, ?Yield]
+  ```
+  
+  [13.2.3 Destructuring Binding Patterns](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-binding-patterns)
+  ```
+  SingleNameBinding [Yield, GeneratorParameter] :
+    [+GeneratorParameter] BindingIdentifier[Yield] TypeHint Initializer[In]opt
+    [~GeneratorParameter] BindingIdentifier[?Yield] TypeHint Initializer[In, ?Yield]opt
+  ```
+  [Iteration Statements](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-iteration-statements)
+  TODO: For the binding variable.
+  
+  [14.1 Function Definitions](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions)
+  ```
+  FunctionDeclaration[Yield, Default] :
+    function BindingIdentifier[?Yield] ( FormalParameters ) TypeHint { FunctionBody }
+    [+Default] function ( FormalParameters ) TypeHint { FunctionBody }
+  FunctionExpression :
+    function BindingIdentifieropt ( FormalParameters ) TypeHint { FunctionBody }
+  
+  FormalParameter[Yield,GeneratorParameter] :
+    BindingElement[?Yield, ?GeneratorParameter] TypeHint
+  ```
+  
+  [14.2 Arrow Function Definitions](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions)
+  TODO: How do you distinguish between return type, and single argument type hint?
+  
+  [14.3 Method Definitions](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-method-definitions)
+  ```
+  MethodDefinition[Yield] :
+    PropertyName[?Yield] ( StrictFormalParameters ) TypeHint { FunctionBody }
+    GeneratorMethod[?Yield]
+    get PropertyName[?Yield] ( ) TypeHint { FunctionBody }
+    set PropertyName[?Yield] ( PropertySetParameterList ) { FunctionBody }
+  ```
+  TODO: does `set` need a TypeHint? Probably not...
+  
+  [14.4 Genrator Function Definitions](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions)
+  ```
+  GeneratorMethod[Yield] :
+    * PropertyName[?Yield] ( StrictFormalParameters[Yield,GeneratorParameter] ) TypeHint { GeneratorBody }
+  GeneratorDeclaration[Yield, Default] :
+    function * BindingIdentifier[?Yield] ( FormalParameters[Yield,GeneratorParameter] ) TypeHint { GeneratorBody }
+    [+Default] function * ( FormalParameters[Yield,GeneratorParameter] ) TypeHint { GeneratorBody }
+  GeneratorExpression :
+    function * BindingIdentifier[Yield]opt ( FormalParameters[Yield,GeneratorParameter] ) TypeHint { GeneratorBody }
+  ```

--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ class Point3 {
 ```
 
 ### Syntax ###
+  [TODO TypeHint](https://people.mozilla.org/~jorendorff/es6-draft.html)
+  
+  ```
+  TypeHint :
+    TODO
+  ```
+
 
   [12.2.5 Object Initializer](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initializer)
   
@@ -181,7 +188,7 @@ class Point3 {
   ```
   TODO: does `set` need a TypeHint? Probably not...
   
-  [14.4 Genrator Function Definitions](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions)
+  [14.4 Generator Function Definitions](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions)
   ```
   GeneratorMethod[Yield] :
     * PropertyName[?Yield] ( StrictFormalParameters[Yield,GeneratorParameter] ) TypeHint { GeneratorBody }


### PR DESCRIPTION
This is a naive first pass through the syntax to see where the type hints would need to go. I've probably also missed a few places.

I'm still also missing the actual syntax for `TypeHint`

I couple things that need thinking though:
- Rest and Spread, do they need hinting?
- Single argument lambdas: `arg type => 1` what does `type` refer to?
- Casting, if any.
